### PR TITLE
chore(app): change message for stack name selection when interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Then you select stack names in the UI.
 
 ```bash
 ? Select StackName.
-Nested child stacks and XXX_IN_PROGRESS(e.g. ROLLBACK_IN_PROGRESS) status stacks are not displayed.
+Nested child stacks, XXX_IN_PROGRESS(e.g. ROLLBACK_IN_PROGRESS) status stacks and EnableTerminationProtection stacks are not displayed.
   [Use arrows to move, type to filter]
 > test-goto-stack-1
   test-goto-stack-2

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -173,7 +173,7 @@ func (a *App) selectStackName(stackNames []string) string {
 	var stackName string
 
 	label := "Select StackName." + "\n" +
-		"Nested child stacks and XXX_IN_PROGRESS(e.g. ROLLBACK_IN_PROGRESS) status stacks are not displayed." +
+		"Nested child stacks, XXX_IN_PROGRESS(e.g. ROLLBACK_IN_PROGRESS) status stacks and EnableTerminationProtection stacks are not displayed." +
 		"\n"
 
 	for {


### PR DESCRIPTION
- old: Nested child stacks and XXX_IN_PROGRESS(e.g. ROLLBACK_IN_PROGRESS) status stacks are not displayed.
- new: Nested child stacks, XXX_IN_PROGRESS(e.g. ROLLBACK_IN_PROGRESS) status stacks and EnableTerminationProtection stacks are not displayed.