### PR TITLE
feat(io): keep filter for resource types selection active in interactive mode

### DIFF
--- a/internal/io/input.go
+++ b/internal/io/input.go
@@ -18,7 +18,7 @@ func GetCheckboxes(label string, opts []string) []string {
 		Message: label,
 		Options: opts,
 	}
-	survey.AskOne(prompt, &res)
+	survey.AskOne(prompt, &res, survey.WithKeepFilter(true))
 
 	return res
 }


### PR DESCRIPTION
Until now, if we entered a filter word on the selection screen and then selected any choice, the word we entered was cleared and all items were displayed again. With this change, the filter word will persist.

```
? Select ResourceTypes you wish to delete even if DELETE_FAILED.
However, if a resource can be deleted without becoming DELETE_FAILED by the normal CloudFormation stack deletion feature, the resource will be deleted even if you do not select that resource type. 
 AWS  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
  [x]  AWS::S3::Bucket
> [x]  AWS::IAM::Role
  [ ]  AWS::ECR::Repository
  [ ]  AWS::Backup::BackupVault
  [ ]  AWS::CloudFormation::Stack
```

Related to [this issue](https://github.com/go-to-k/delstack/issues/306).