### PR TITLE
docs: add mise installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ For CDK apps, `delstack cdk` synthesizes, discovers all stacks (including cross-
   aqua g -i go-to-k/delstack
   ```
 
+- mise
+
+  ```bash
+  mise use -g aqua:go-to-k/delstack
+  ```
+
 - Binary
   - [Releases](https://github.com/go-to-k/delstack/releases)
 - Git Clone and install (for developers)


### PR DESCRIPTION
## Summary

- Add mise installation method to README, using the aqua backend (which reuses the existing aqua registry entry).

## Test plan

- [x] Verified the new section renders correctly in README.md