### PR TITLE
feat: allow deletion of stacks in REVIEW_IN_PROGRESS state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     tags-ignore:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     branches:
-      - '*'
+      - '**'
 
 jobs:
   test:

--- a/internal/operation/cloudformation_stack.go
+++ b/internal/operation/cloudformation_stack.go
@@ -27,6 +27,8 @@ const StackNameRule = `^arn:aws:cloudformation:[^:]*:[0-9]*:stack/([^/]*)/.*$`
 
 // Except xxInProgress
 // StackStatusDeleteComplete is not included because DescribeStacks does not return a DELETE_COMPLETE stack.
+// StackStatusReviewInProgress is not included because a stack in this state has no actual resources
+// (only metadata from an unexecuted change set) and DeleteStack accepts it.
 var StackStatusExceptionsForDescribeStacks = []types.StackStatus{
 	types.StackStatusCreateInProgress,
 	types.StackStatusRollbackInProgress,
@@ -35,7 +37,6 @@ var StackStatusExceptionsForDescribeStacks = []types.StackStatus{
 	types.StackStatusUpdateCompleteCleanupInProgress,
 	types.StackStatusUpdateRollbackInProgress,
 	types.StackStatusUpdateRollbackCompleteCleanupInProgress,
-	types.StackStatusReviewInProgress,
 	types.StackStatusImportInProgress,
 	types.StackStatusImportRollbackInProgress,
 }


### PR DESCRIPTION
## Summary

### 1. Allow deletion of stacks in `REVIEW_IN_PROGRESS`

- `REVIEW_IN_PROGRESS` is set when a change set is created for a new stack but has not been executed yet. The stack has no actual resources, just metadata, and the CloudFormation `DeleteStack` API accepts it directly.
- Previously delstack treated it as an `XxxInProgress` state and refused to delete, forcing users to clean these orphaned stacks up by hand.
- Removed `StackStatusReviewInProgress` from `StackStatusExceptionsForDescribeStacks` so it flows through `deleteStackNormally` like any other deletable state. `RemoveDeletionPolicy` (used by `-f`) already skips non-updatable states via `isUpdatableStackStatus`, so no additional handling is needed.
- As a side effect, `REVIEW_IN_PROGRESS` stacks are now also surfaced in `ListStacksFilteredByKeyword` results, which is the consistent behavior.

#### Reproduction

```
$ delstack -s my-stack -p my-profile
ERR OperationInProgressError: Stacks with XxxInProgress cannot be deleted, but REVIEW_IN_PROGRESS: my-stack
```

After this change, the same command deletes the stack normally.

### 2. Fix `ci.yml` branch filter

- The `'*'` glob in GitHub Actions does not match the `/` character, so feature branches like `feat/foo` never triggered `ci.yml` and CI was silently skipped on every feature-branch push.
- Switched to `'**'` so all branches run CI on push.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/operation/...`
- [x] `make lint_diff`
- [x] CI now runs on this feature branch (verified after pushing the workflow fix)
- [ ] Manual: delete a real stack in `REVIEW_IN_PROGRESS` state
