### PR TITLE
fix: keep temporary template S3 bucket name within 63-character limit

### DIFF
--- a/internal/operation/cloudformation_stack.go
+++ b/internal/operation/cloudformation_stack.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -533,7 +534,9 @@ func (o *CloudFormationStackOperator) uploadTemplateToS3(ctx context.Context, st
 		return nil, fmt.Errorf("TemplateS3UploadError: failed to extract account ID from stack ARN")
 	}
 
-	timestamp := fmt.Sprintf("%d", time.Now().UnixNano())
+	// Base36-encode the nanosecond timestamp to keep the bucket name within S3's 63-character limit
+	// (a 19-digit decimal timestamp overflows the limit for longer region names such as ap-northeast-1).
+	timestamp := strconv.FormatInt(time.Now().UnixNano(), 36)
 	bucketName := fmt.Sprintf("delstack-templates-%s-%s-%s", accountID, o.config.Region, timestamp)
 
 	// Ensure bucket cleanup if upload fails (only after bucket is created)

--- a/internal/operation/cloudformation_stack_test.go
+++ b/internal/operation/cloudformation_stack_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -4360,6 +4361,64 @@ func TestCloudFormationStackOperator_RemoveDeletionPolicy(t *testing.T) {
 			if tt.wantErr && err.Error() != tt.want.Error() {
 				t.Errorf("err = %#v, want %#v", err.Error(), tt.want.Error())
 				return
+			}
+		})
+	}
+}
+
+func TestCloudFormationStackOperator_uploadTemplateToS3(t *testing.T) {
+	io.NewLogger(false)
+
+	// AWS S3 bucket names must be at most 63 characters and match the S3 naming rules.
+	// A 19-digit decimal nanosecond timestamp used to overflow this limit for longer
+	// region names (e.g. ap-northeast-1), causing InvalidBucketName on CreateBucket.
+	bucketNameRegex := regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`)
+
+	cases := []struct {
+		name   string
+		region string
+	}{
+		{name: "long region name (ap-northeast-1) stays within the 63-character limit", region: "ap-northeast-1"},
+		{name: "short region name (us-east-1)", region: "us-east-1"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			cloudformationMock := client.NewMockICloudFormation(ctrl)
+
+			s3Mock := client.NewMockIS3(ctrl)
+
+			var capturedBucketName string
+			s3Mock.EXPECT().CreateBucket(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, bucketName *string) error {
+					capturedBucketName = *bucketName
+					return nil
+				},
+			)
+			s3Mock.EXPECT().PutObject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+			cloudformationStackOperator := NewCloudFormationStackOperator(aws.Config{Region: tt.region}, cloudformationMock, s3Mock)
+
+			stackName := aws.String("test-stack")
+			template := aws.String(`{"Resources":{}}`)
+			stack := &types.Stack{
+				StackId: aws.String("arn:aws:cloudformation:" + tt.region + ":583942117338:stack/test-stack/guid"),
+			}
+
+			result, err := cloudformationStackOperator.uploadTemplateToS3(context.Background(), stackName, template, stack)
+			if err != nil {
+				t.Fatalf("uploadTemplateToS3 returned error: %v", err)
+			}
+			if result == nil || result.BucketName == nil {
+				t.Fatalf("uploadTemplateToS3 returned nil result")
+			}
+
+			if len(capturedBucketName) > 63 {
+				t.Errorf("bucket name exceeds the S3 63-character limit (%d): %s", len(capturedBucketName), capturedBucketName)
+			}
+			if !bucketNameRegex.MatchString(capturedBucketName) {
+				t.Errorf("bucket name is not a valid S3 bucket name: %s", capturedBucketName)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Fixes a bug where force-deleting a stack with a large template (over 51,200 bytes) fails when creating the temporary S3 bucket used to upload the rewritten template.

```
ERR Failed to remove deletion policy: TemplateS3UploadError: failed to create S3 bucket:
[resource delstack-templates-583942117338-ap-northeast-1-1782712792531111000]
... api error InvalidBucketName: The specified bucket is not valid.
```

## Cause

The bucket name was built as `delstack-templates-<accountID>-<region>-<timestamp>` with `timestamp = time.Now().UnixNano()`, which is 19 decimal digits.

For a 12-digit account ID and a longer region name such as `ap-northeast-1` (14 chars), the name reaches 66 characters and exceeds the S3 63-character bucket name limit, so `CreateBucket` fails with `InvalidBucketName`. Shorter region names like `us-east-1` happened to stay within the limit (61 chars), which is why this only reproduced in certain regions.

| part | length |
|---|---|
| `delstack-templates-` | 19 |
| accountID + `-` | 13 |
| `ap-northeast-1` + `-` | 15 |
| nanosecond timestamp (decimal) | 19 |
| **total** | **66** |

## Fix

Encode the nanosecond timestamp in base36 (`strconv.FormatInt(time.Now().UnixNano(), 36)`), shortening it to ~12 characters (total 59) while preserving uniqueness.

## Test

Added `TestCloudFormationStackOperator_uploadTemplateToS3`, which captures the generated bucket name and asserts it stays within the 63-character limit and matches S3 bucket naming rules, covering both a long region (`ap-northeast-1`) and a short region (`us-east-1`).
