### PR TITLE
fix: prevent deadlock when cross-region CDK stacks share the same stack name

### DIFF
--- a/internal/app/cdk_deleter.go
+++ b/internal/app/cdk_deleter.go
@@ -34,12 +34,24 @@ func NewCdkDeleter(profile string, forceMode bool, concurrencyNumber int) *CdkDe
 	}
 }
 
+// stackIdentity returns a unique key for a stack: the Cloud Assembly artifact key
+// (Identifier), which stays unique even when cross-region stacks share the same
+// CloudFormation stack name. It falls back to StackName only if Identifier is unset.
+func stackIdentity(s cdk.StackInfo) string {
+	if s.Identifier != "" {
+		return s.Identifier
+	}
+	return s.StackName
+}
+
 func (d *CdkDeleter) DeleteStacks(ctx context.Context, stacks []cdk.StackInfo) error {
 	regionStacks, regions := d.groupByRegion(stacks)
 
+	// Key by Identifier (unique artifact key), not StackName, because cross-region
+	// stacks can share the same CloudFormation stack name.
 	stackMap := make(map[string]cdk.StackInfo)
 	for _, s := range stacks {
-		stackMap[s.StackName] = s
+		stackMap[stackIdentity(s)] = s
 	}
 
 	if d.hasCrossRegionDependencies(stacks, stackMap) {
@@ -89,13 +101,13 @@ func (d *CdkDeleter) deleteStacksWithCrossRegionDeps(ctx context.Context, stacks
 	dependents := make(map[string][]string) // stack -> stacks that depend on it (i.e. stacks that become unblocked when this stack is deleted)
 
 	for _, s := range stacks {
-		reverseInDegree[s.StackName] = 0
+		reverseInDegree[stackIdentity(s)] = 0
 	}
 	for _, s := range stacks {
 		for _, dep := range s.Dependencies {
 			if _, ok := stackMap[dep]; ok {
 				reverseInDegree[dep]++
-				dependents[s.StackName] = append(dependents[s.StackName], dep)
+				dependents[stackIdentity(s)] = append(dependents[stackIdentity(s)], dep)
 			}
 		}
 	}
@@ -135,7 +147,7 @@ func (d *CdkDeleter) deleteStacksWithCrossRegionDeps(ctx context.Context, stacks
 
 	var wg sync.WaitGroup
 
-	startDeletion := func(stackName string) {
+	startDeletion := func(identifier string) {
 		defer wg.Done()
 
 		// Acquire semaphore inside goroutine to avoid blocking the main goroutine.
@@ -150,11 +162,11 @@ func (d *CdkDeleter) deleteStacksWithCrossRegionDeps(ctx context.Context, stacks
 		}
 		defer sem.Release(1)
 
-		s := stackMap[stackName]
+		s := stackMap[identifier]
 		config := configCache[s.Region]
 		operatorFactory := factoryCache[s.Region]
 
-		if err := d.executor.Execute(deleteCtx, stackName, config, operatorFactory, d.forceMode, true); err != nil {
+		if err := d.executor.Execute(deleteCtx, s.StackName, config, operatorFactory, d.forceMode, true); err != nil {
 			select {
 			case errorChan <- err:
 			default:
@@ -163,14 +175,14 @@ func (d *CdkDeleter) deleteStacksWithCrossRegionDeps(ctx context.Context, stacks
 			return
 		}
 
-		completionChan <- stackName
+		completionChan <- identifier
 	}
 
 	// Start initial deletions for stacks with reverse in-degree 0
 	for _, s := range stacks {
-		if reverseInDegree[s.StackName] == 0 {
+		if reverseInDegree[stackIdentity(s)] == 0 {
 			wg.Add(1)
-			go startDeletion(s.StackName)
+			go startDeletion(stackIdentity(s))
 		}
 	}
 
@@ -189,12 +201,13 @@ func (d *CdkDeleter) deleteStacksWithCrossRegionDeps(ctx context.Context, stacks
 		case err := <-errorChan:
 			return err
 
-		case deletedStackName := <-completionChan:
+		case deletedIdentifier := <-completionChan:
 			deletedCount++
-			deletedStacks = append(deletedStacks, deletedStackName)
+			deleted := stackMap[deletedIdentifier]
+			deletedStacks = append(deletedStacks, fmt.Sprintf("%s (%s)", deleted.StackName, deleted.Region))
 			io.Logger.Info().Msgf("Progress: %d/%d stacks deleted [%s]", deletedCount, totalStackCount, strings.Join(deletedStacks, ", "))
 
-			for _, depStack := range dependents[deletedStackName] {
+			for _, depStack := range dependents[deletedIdentifier] {
 				reverseInDegree[depStack]--
 				if reverseInDegree[depStack] == 0 {
 					wg.Add(1)

--- a/internal/app/cdk_deleter_test.go
+++ b/internal/app/cdk_deleter_test.go
@@ -97,8 +97,8 @@ func TestCdkDeleter_DeleteStacks_CrossRegionDeps(t *testing.T) {
 	})
 
 	stacks := []cdk.StackInfo{
-		{StackName: "Edge", Region: "us-east-1"},
-		{StackName: "Main", Region: "ap-northeast-1", Dependencies: []string{"Edge"}},
+		{Identifier: "Edge", StackName: "Edge", Region: "us-east-1"},
+		{Identifier: "Main", StackName: "Main", Region: "ap-northeast-1", Dependencies: []string{"Edge"}},
 	}
 
 	err := d.DeleteStacks(context.Background(), stacks)
@@ -114,6 +114,39 @@ func TestCdkDeleter_DeleteStacks_CrossRegionDeps(t *testing.T) {
 	}
 	if deletionOrder[1] != "Edge" {
 		t.Errorf("expected Edge to be deleted second, got %s", deletionOrder[1])
+	}
+}
+
+// TestCdkDeleter_DeleteStacks_CrossRegionDeps_SameStackName reproduces the deadlock
+// where two cross-region stacks share the same CloudFormation stack name (e.g. a
+// CloudFront us-east-1 support stack reusing the main stack name). Identity must be
+// the unique artifact key, otherwise the dependency graph collapses and no stack ever
+// reaches in-degree 0.
+func TestCdkDeleter_DeleteStacks_CrossRegionDeps_SameStackName(t *testing.T) {
+	io.NewLogger(false)
+
+	var mu sync.Mutex
+	var deletionOrder []string
+
+	d := newTestCdkDeleter(&trackingExecutor{
+		mu:    &mu,
+		order: &deletionOrder,
+	})
+
+	// Both stacks are named "app" but live in different regions; the tokyo stack
+	// depends on the us-east-1 support stack (referenced by its artifact key).
+	stacks := []cdk.StackInfo{
+		{Identifier: "app", StackName: "app", Region: "ap-northeast-1", Dependencies: []string{"app-us-east-1"}},
+		{Identifier: "app-us-east-1", StackName: "app", Region: "us-east-1"},
+	}
+
+	err := d.DeleteStacks(context.Background(), stacks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(deletionOrder) != 2 {
+		t.Fatalf("expected 2 stacks deleted, got %d: %v", len(deletionOrder), deletionOrder)
 	}
 }
 

--- a/internal/app/cdk_select.go
+++ b/internal/app/cdk_select.go
@@ -58,6 +58,7 @@ func (s *CdkStackSelector) matchByPatterns(stacks []cdk.StackInfo) ([]cdk.StackI
 
 	// Split patterns into exact names and glob patterns
 	exactSet := make(map[string]struct{})
+	matchedExact := make(map[string]struct{})
 	var globs []string
 	for _, p := range s.stackNames {
 		if s.isGlobPattern(p) {
@@ -68,15 +69,19 @@ func (s *CdkStackSelector) matchByPatterns(stacks []cdk.StackInfo) ([]cdk.StackI
 	}
 
 	for _, st := range stacks {
-		if _, ok := seen[st.StackName]; ok {
+		// Dedup by Identifier, not StackName, so cross-region stacks that share the
+		// same CloudFormation stack name are both selectable.
+		id := stackIdentity(st)
+		if _, ok := seen[id]; ok {
 			continue
 		}
 
-		// Check exact match
+		// Check exact match. The name is not removed from exactSet so it can also
+		// match another stack with the same name in a different region.
 		if _, ok := exactSet[st.StackName]; ok {
 			selected = append(selected, st)
-			seen[st.StackName] = struct{}{}
-			delete(exactSet, st.StackName)
+			seen[id] = struct{}{}
+			matchedExact[st.StackName] = struct{}{}
 			continue
 		}
 
@@ -88,7 +93,7 @@ func (s *CdkStackSelector) matchByPatterns(stacks []cdk.StackInfo) ([]cdk.StackI
 			}
 			if matched {
 				selected = append(selected, st)
-				seen[st.StackName] = struct{}{}
+				seen[id] = struct{}{}
 				break
 			}
 		}
@@ -97,7 +102,9 @@ func (s *CdkStackSelector) matchByPatterns(stacks []cdk.StackInfo) ([]cdk.StackI
 	// Collect unmatched exact names (glob patterns that match nothing are not errors)
 	var unmatched []string
 	for name := range exactSet {
-		unmatched = append(unmatched, name)
+		if _, ok := matchedExact[name]; !ok {
+			unmatched = append(unmatched, name)
+		}
 	}
 
 	return selected, unmatched, nil

--- a/internal/app/cdk_select_test.go
+++ b/internal/app/cdk_select_test.go
@@ -10,7 +10,7 @@ import (
 func makeStacks(names ...string) []cdk.StackInfo {
 	stacks := make([]cdk.StackInfo, len(names))
 	for i, n := range names {
-		stacks[i] = cdk.StackInfo{StackName: n, Region: "us-east-1"}
+		stacks[i] = cdk.StackInfo{Identifier: n, StackName: n, Region: "us-east-1"}
 	}
 	return stacks
 }

--- a/internal/cdk/manifest.go
+++ b/internal/cdk/manifest.go
@@ -9,9 +9,16 @@ import (
 )
 
 type StackInfo struct {
-	StackName             string
-	Region                string
-	Account               string
+	// Identifier is the unique Cloud Assembly artifact key. Unlike StackName it is
+	// guaranteed unique even when cross-region stacks share the same CloudFormation
+	// stack name (e.g. a CloudFront us-east-1 support stack reusing the main stack
+	// name). It is used as the identity for dependency-graph resolution.
+	Identifier string
+	StackName  string
+	Region     string
+	Account    string
+	// Dependencies holds the Identifier (artifact key) of each stack this stack
+	// depends on, not the StackName, to stay unambiguous when names collide.
 	Dependencies          []string
 	TerminationProtection bool
 }
@@ -54,12 +61,12 @@ func parseManifestRecursive(dir string) ([]StackInfo, error) {
 	}
 
 	// Build a set of stack artifact keys for dependency filtering
-	stackArtifactKeys := make(map[string]string) // artifact key -> stack name
+	stackArtifactKeys := make(map[string]struct{})
 	for key, art := range m.Artifacts {
 		if art.Type != "aws:cloudformation:stack" {
 			continue
 		}
-		stackArtifactKeys[key] = resolveStackName(key, art)
+		stackArtifactKeys[key] = struct{}{}
 	}
 
 	var stacks []StackInfo
@@ -70,15 +77,18 @@ func parseManifestRecursive(dir string) ([]StackInfo, error) {
 
 			account, region := parseEnvironment(art.Environment)
 
-			// Filter dependencies: only include other stack artifacts (exclude .assets etc.)
+			// Filter dependencies: only include other stack artifacts (exclude .assets etc.).
+			// Keep the artifact key (unique) instead of the resolved stack name, which can
+			// collide across regions.
 			var deps []string
 			for _, dep := range art.Dependencies {
-				if depName, ok := stackArtifactKeys[dep]; ok {
-					deps = append(deps, depName)
+				if _, ok := stackArtifactKeys[dep]; ok {
+					deps = append(deps, dep)
 				}
 			}
 
 			stacks = append(stacks, StackInfo{
+				Identifier:   key,
 				StackName:    name,
 				Region:       region,
 				Account:      account,

--- a/internal/cdk/manifest_test.go
+++ b/internal/cdk/manifest_test.go
@@ -204,6 +204,67 @@ func TestParseManifest_FallbackToArtifactKey(t *testing.T) {
 	}
 }
 
+// TestParseManifest_CrossRegionSameStackName covers a real CDK app where a
+// CloudFront us-east-1 support stack reuses the main stack's CloudFormation name via
+// the stackName property. Identity must come from the unique artifact key, and the
+// dependency must be expressed as that key (not the ambiguous stack name).
+func TestParseManifest_CrossRegionSameStackName(t *testing.T) {
+	dir := t.TempDir()
+	manifestJSON := `{
+  "version": "52.0.0",
+  "artifacts": {
+    "AiApi-us-east-1": {
+      "type": "aws:cloudformation:stack",
+      "environment": "aws://123456789012/us-east-1",
+      "properties": { "templateFile": "AiApi-us-east-1.template.json", "stackName": "AiApi" },
+      "displayName": "AiApi-us-east-1"
+    },
+    "AiApi": {
+      "type": "aws:cloudformation:stack",
+      "environment": "aws://123456789012/ap-northeast-1",
+      "properties": { "templateFile": "AiApi.template.json" },
+      "dependencies": ["AiApi-us-east-1"],
+      "displayName": "AiApi"
+    }
+  }
+}`
+	writeManifest(t, dir, manifestJSON)
+
+	stacks, err := ParseManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stacks) != 2 {
+		t.Fatalf("expected 2 stacks, got %d", len(stacks))
+	}
+
+	byIdentifier := make(map[string]StackInfo)
+	for _, s := range stacks {
+		byIdentifier[s.Identifier] = s
+	}
+
+	main, ok := byIdentifier["AiApi"]
+	if !ok {
+		t.Fatal("stack with identifier 'AiApi' not found")
+	}
+	support, ok := byIdentifier["AiApi-us-east-1"]
+	if !ok {
+		t.Fatal("stack with identifier 'AiApi-us-east-1' not found")
+	}
+
+	// Both share the same CloudFormation stack name.
+	if main.StackName != "AiApi" || support.StackName != "AiApi" {
+		t.Errorf("expected both stack names to be 'AiApi', got main=%q support=%q", main.StackName, support.StackName)
+	}
+	if main.Region != "ap-northeast-1" || support.Region != "us-east-1" {
+		t.Errorf("unexpected regions: main=%q support=%q", main.Region, support.Region)
+	}
+	// The dependency must be the unique artifact key, not the shared stack name.
+	if len(main.Dependencies) != 1 || main.Dependencies[0] != "AiApi-us-east-1" {
+		t.Errorf("expected main to depend on 'AiApi-us-east-1', got %v", main.Dependencies)
+	}
+}
+
 func TestParseManifest_NoStacks(t *testing.T) {
 	dir := t.TempDir()
 	manifestJSON := `{
@@ -317,8 +378,9 @@ func TestParseManifest_NestedAssembly_Stage(t *testing.T) {
 	if stackB.Region != "ap-northeast-1" {
 		t.Errorf("expected region ap-northeast-1, got %s", stackB.Region)
 	}
-	if len(stackB.Dependencies) != 1 || stackB.Dependencies[0] != "my-stage-stack-a" {
-		t.Errorf("expected StackB to depend on my-stage-stack-a, got %v", stackB.Dependencies)
+	// Dependencies hold the artifact key (unique), not the resolved stack name.
+	if len(stackB.Dependencies) != 1 || stackB.Dependencies[0] != "MyStage-StackA" {
+		t.Errorf("expected StackB to depend on MyStage-StackA, got %v", stackB.Dependencies)
 	}
 }
 


### PR DESCRIPTION
## Problem

`delstack cdk` deadlocks when two cross-region stacks share the same CloudFormation stack name:

```
INF Cross-region dependencies detected. Deleting stacks in dependency order...
fatal error: all goroutines are asleep - deadlock!
```

This happens with a common CDK pattern: a CloudFront `us-east-1` support stack reuses the main stack's CloudFormation name via the `stackName` property. Both stacks resolve to the same `StackName` (e.g. `AiApi`), living in different regions.

### Root cause

`CdkDeleter` builds its reverse-topological dependency graph keyed by `StackName`. When two distinct stacks share a name:

1. `stackMap` collapses to a single entry.
2. The main stack's dependency on the support stack resolves (by name) to the shared key, giving `reverseInDegree == 1`.
3. **No stack ever reaches in-degree 0**, so no initial deletion starts and the completion loop blocks forever.

Additionally, `Dependencies` were stored as resolved stack names, which are ambiguous when names collide across regions.

## Fix

Use the unique Cloud Assembly **artifact key** as the graph identity:

- `StackInfo` gains an `Identifier` field, and `Dependencies` now hold artifact keys instead of resolved stack names.
- `CdkDeleter` keys its graph by identity (`stackIdentity`, falling back to `StackName` when unset) and deletes by `StackName` + `Region`.
- Stack selection (`-s`) dedups by identity, fixing a related latent bug where only one of two same-named cross-region stacks was selectable.

## Tests

- `TestCdkDeleter_DeleteStacks_CrossRegionDeps_SameStackName` reproduces the reported deadlock using a mock executor (no real AWS calls).
- `TestParseManifest_CrossRegionSameStackName` covers parsing a manifest where `stackName` override causes a name collision.
- Existing dependency/selection assertions updated for the artifact-key identity.

No real stacks were deleted during verification; the regression test with mocks confirms the fix.