### PR TITLE
fix: use artifact key as CDK stack name instead of slash-containing displayName

### DIFF
--- a/internal/cdk/manifest.go
+++ b/internal/cdk/manifest.go
@@ -114,13 +114,16 @@ func parseManifestRecursive(dir string) ([]StackInfo, error) {
 }
 
 // resolveStackName returns the CloudFormation stack name.
-// Priority: properties.stackName > displayName > artifact key
+// Priority: properties.stackName > artifact key.
+//
+// displayName is intentionally NOT used as the stack name. For nested constructs
+// (CDK Stages, integ-runner DeployAssert stacks) displayName is a human-readable
+// construct path like "Foo/Bar/Baz" that violates the CloudFormation stack name
+// constraint ([a-zA-Z][-a-zA-Z0-9]*). The real CFN stack name is the artifact key,
+// which CDK derives by sanitizing that path.
 func resolveStackName(artifactKey string, art artifact) string {
 	if art.Properties.StackName != "" {
 		return art.Properties.StackName
-	}
-	if art.DisplayName != "" {
-		return art.DisplayName
 	}
 	return artifactKey
 }

--- a/internal/cdk/manifest_test.go
+++ b/internal/cdk/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -201,6 +202,42 @@ func TestParseManifest_FallbackToArtifactKey(t *testing.T) {
 
 	if stacks[0].StackName != "MyStackArtifactKey" {
 		t.Errorf("expected stack name 'MyStackArtifactKey', got '%s'", stacks[0].StackName)
+	}
+}
+
+// TestParseManifest_NestedConstructDisplayName reproduces an integ-runner snapshot
+// where a DeployAssert stack has no stackName property and a displayName that is a
+// construct path with slashes. The resolved CloudFormation stack name must be the
+// sanitized artifact key, not the slash-containing displayName (which would fail the
+// DescribeStacks stackName validation).
+func TestParseManifest_NestedConstructDisplayName(t *testing.T) {
+	dir := t.TempDir()
+	manifestJSON := `{
+  "version": "52.0.0",
+  "artifacts": {
+    "MultiRegionStackWeakTestDefaultTestDeployAssert395291BD": {
+      "type": "aws:cloudformation:stack",
+      "environment": "aws://unknown-account/unknown-region",
+      "displayName": "MultiRegionStackWeakTest/DefaultTest/DeployAssert"
+    }
+  }
+}`
+	writeManifest(t, dir, manifestJSON)
+
+	stacks, err := ParseManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+
+	const wantName = "MultiRegionStackWeakTestDefaultTestDeployAssert395291BD"
+	if stacks[0].StackName != wantName {
+		t.Errorf("expected stack name %q (artifact key), got %q", wantName, stacks[0].StackName)
+	}
+	if strings.ContainsRune(stacks[0].StackName, '/') {
+		t.Errorf("stack name must not contain '/', got %q", stacks[0].StackName)
 	}
 }
 


### PR DESCRIPTION
## Problem

`delstack cdk -a <cdk.out>` fails on a snapshot that contains nested constructs such as integ-runner `DeployAssert` stacks:

```
ERR [resource MultiRegionStackWeakTest/DefaultTest/DeployAssert] operation error CloudFormation: DescribeStacks, ... api error ValidationError: 1 validation error detected: Value 'MultiRegionStackWeakTest/DefaultTest/DeployAssert' at 'stackName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/._+]*
```

### Root cause

`resolveStackName` used `displayName` as the CloudFormation stack name (`properties.stackName > displayName > artifactKey`).

For nested constructs (CDK Stages, integ-runner `DeployAssert` stacks) that have no `stackName` property, `displayName` is a human-readable construct **path** with slashes, e.g. `MultiRegionStackWeakTest/DefaultTest/DeployAssert`. That violates the CloudFormation stack-name constraint `[a-zA-Z][-a-zA-Z0-9]*`, so `DescribeStacks` rejects it before the existence check can skip the stack.

The real CFN stack name is the **artifact key** (`MultiRegionStackWeakTestDefaultTestDeployAssert395291BD`), which CDK derives by sanitizing that path.

## Fix

Drop the `displayName` fallback in `resolveStackName`: `properties.stackName > artifactKey`.

- Top-level stacks (`displayName == artifactKey`) and stacks with an explicit `stackName` property are unaffected.
- Only nested constructs now resolve to their correct, valid CFN stack name.

## Tests

- `TestParseManifest_NestedConstructDisplayName` reproduces the DeployAssert case and asserts the resolved name is the sanitized artifact key (and contains no `/`).