### PR TITLE
ci: check the formatting of the e2e modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         run: make build
       - name: test
         run: make test_view
+      # golangci-lint runs against the root module only, so the reviewdog job never
+      # looks at e2e/: every scenario there is a separate Go module. Check their
+      # formatting here, where a plain Go toolchain is already set up.
+      - name: gofmt (e2e modules)
+        run: make gofmt_e2e
       - name: Archive code coverage results
         uses: actions/upload-artifact@v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ No circular dependencies. `internal/app` must not depend on `pkg/client` directl
 - `make run OPT="<options>"`: Run delstack locally
 - `make test`: Run all tests
 - `make mockgen`: Regenerate mocks
-- `make lint`: Run linter. The version is pinned in [.golangci-version](.golangci-version) and read by both `make lint` and CI, because golangci-lint bundles its own copy of the Go formatter independently of the Go toolchain in `go.mod`. Install that version; `make lint` warns if yours differs.
+- `make lint`: Run linter. The version is pinned in [.golangci-version](.golangci-version) and read by both `make lint` and CI, because golangci-lint bundles its own copy of the Go formatter independently of the Go toolchain in `go.mod`. Install that version; `make lint` warns if yours differs. It also runs `gofmt` over `e2e/`, which golangci-lint never sees because every scenario there is its own Go module.
 
 ## Adding New Resource Support
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TEST_COV_RESULT := "$$(go test -race -cover -v ./... -coverpkg=./... -coverprofi
 
 FAIL_CHECK := "^[^\s\t]*FAIL[^\s\t]*$$"
 
-.PHONY: test_diff test test_view lint lint_diff lint_version_check mockgen shadow cognit deadcode run build install clean testgen_full testgen_full_retain testgen_large_template testgen_dependency testgen_dependency_retain testgen_preprocessor testgen_vpc_lambda testgen_lambda_edge testgen_deletion_protection testgen_deletion_protection_no_tp testgen_cdk_integration testgen_create_failed testgen_help e2e_full e2e_full_retain e2e_large_template e2e_dependency e2e_dependency_retain e2e_preprocessor e2e_vpc_lambda e2e_lambda_edge e2e_deletion_protection e2e_deletion_protection_no_tp e2e_cdk_integration e2e_create_failed e2e_help
+.PHONY: test_diff test test_view lint lint_diff lint_version_check gofmt_e2e mockgen shadow cognit deadcode run build install clean testgen_full testgen_full_retain testgen_large_template testgen_dependency testgen_dependency_retain testgen_preprocessor testgen_vpc_lambda testgen_lambda_edge testgen_deletion_protection testgen_deletion_protection_no_tp testgen_cdk_integration testgen_create_failed testgen_help e2e_full e2e_full_retain e2e_large_template e2e_dependency e2e_dependency_retain e2e_preprocessor e2e_vpc_lambda e2e_lambda_edge e2e_deletion_protection e2e_deletion_protection_no_tp e2e_cdk_integration e2e_create_failed e2e_help
 
 test_diff:
 	@! echo $(TEST_DIFF_RESULT) | $(COLORIZE_PASS) | $(COLORIZE_FAIL) | tee /dev/stderr | grep $(FAIL_CHECK) > /dev/null
@@ -36,10 +36,21 @@ test_view:
 	rm cover.out.tmp
 	go tool cover -func=cover.out
 	go tool cover -html=cover.out -o cover.html
-lint: lint_version_check
+lint: lint_version_check gofmt_e2e
 	golangci-lint run
-lint_diff: lint_version_check
+lint_diff: lint_version_check gofmt_e2e
 	golangci-lint run $$(echo $(DIFF_FILE))
+# golangci-lint only ever sees the root module, so nothing under e2e/ is checked:
+# each scenario there is its own Go module. Running the full linter on all of them
+# would mean downloading the CDK dependency tree on every lint, so check just their
+# formatting, which is what actually drifts.
+gofmt_e2e:
+	@unformatted=$$(gofmt -l e2e); \
+	if [ -n "$$unformatted" ]; then \
+		echo "$(RED)not gofmt-ed (run \`gofmt -w e2e\`):$(RESET)"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 # golangci-lint bundles its own copy of the Go formatter, independent of the Go
 # toolchain in go.mod. A version other than the pinned one can therefore demand a
 # formatting that `gofmt` immediately reverts (Go 1.27 changed the indentation of

--- a/e2e/deletion_protection/cdk/lib/resource/elbv2.go
+++ b/e2e/deletion_protection/cdk/lib/resource/elbv2.go
@@ -10,8 +10,8 @@ import (
 // NewAlb creates an ELBv2 Application Load Balancer with deletion protection enabled.
 func NewAlb(scope constructs.Construct, vpc awsec2.Vpc) awselasticloadbalancingv2.ApplicationLoadBalancer {
 	alb := awselasticloadbalancingv2.NewApplicationLoadBalancer(scope, jsii.String("Alb"), &awselasticloadbalancingv2.ApplicationLoadBalancerProps{
-		Vpc: vpc,
-		InternetFacing:   jsii.Bool(true),
+		Vpc:            vpc,
+		InternetFacing: jsii.Bool(true),
 		VpcSubnets: &awsec2.SubnetSelection{
 			SubnetType: awsec2.SubnetType_PUBLIC,
 		},

--- a/e2e/deletion_protection/deploy.go
+++ b/e2e/deletion_protection/deploy.go
@@ -19,9 +19,9 @@ const (
 )
 
 type Options struct {
-	Profile                  string
-	Stage                    string
-	NoTerminationProtection  bool
+	Profile                 string
+	Stage                   string
+	NoTerminationProtection bool
 }
 
 type DeployStackService struct {

--- a/e2e/preprocessor/cdk/lib/nest/child.go
+++ b/e2e/preprocessor/cdk/lib/nest/child.go
@@ -42,9 +42,9 @@ def handler(event, context):
 
 	// Lambda function in nested stack with VPC (IPv6 enabled)
 	awslambda.NewFunction(stack, jsii.String("ChildLambdaVpcIpv6"), &awslambda.FunctionProps{
-		FunctionName:             jsii.String(props.PjPrefix + "-Child-LambdaVpcIpv6"),
-		Runtime:                  awslambda.Runtime_PYTHON_3_12(),
-		Handler:                  jsii.String("index.handler"),
+		FunctionName: jsii.String(props.PjPrefix + "-Child-LambdaVpcIpv6"),
+		Runtime:      awslambda.Runtime_PYTHON_3_12(),
+		Handler:      jsii.String("index.handler"),
 		Code: awslambda.Code_FromInline(jsii.String(`
 def handler(event, context):
     return {
@@ -52,8 +52,8 @@ def handler(event, context):
         'body': 'Hello from child VPC Lambda with IPv6!'
     }
 `)),
-		Timeout:                  awscdk.Duration_Seconds(jsii.Number(30)),
-		Vpc:                      props.Vpc,
+		Timeout: awscdk.Duration_Seconds(jsii.Number(30)),
+		Vpc:     props.Vpc,
 		VpcSubnets: &awsec2.SubnetSelection{
 			SubnetType: awsec2.SubnetType_PRIVATE_ISOLATED,
 		},


### PR DESCRIPTION
Stacked on #658 — please merge that first, then this one.

## Problem

`golangci-lint run` only ever sees the **root module**. Every scenario under `e2e/` is a separate Go module (15 of them), so the root run never traverses them, and `make lint` has never checked a single line there. The reviewdog job inherits the same blind spot.

Three files had quietly drifted out of `gofmt` shape:

```
e2e/deletion_protection/cdk/lib/resource/elbv2.go
e2e/deletion_protection/deploy.go
e2e/preprocessor/cdk/lib/nest/child.go
```

Plain field-alignment drift, unrelated to any toolchain change — `gofmt` from Go 1.25 and Go 1.27 both report the same three files, so this is not fallout from #659:

```diff
 	alb := awselasticloadbalancingv2.NewApplicationLoadBalancer(scope, jsii.String("Alb"), &awselasticloadbalancingv2.ApplicationLoadBalancerProps{
-		Vpc: vpc,
-		InternetFacing:   jsii.Bool(true),
+		Vpc:            vpc,
+		InternetFacing: jsii.Bool(true),
```

## Change

- Reformat the three files.
- Add a `gofmt_e2e` target, run by `make lint`, `make lint_diff` and the CI `test` job (which already has a plain Go toolchain set up).

## Why formatting only, not the full linter

Running golangci-lint across 15 modules would mean downloading the CDK dependency tree on every lint — minutes per run, for deploy scripts. Formatting is what actually drifts in code like this, and it is what nothing was catching. Checking it costs milliseconds.

## Verification

- `make gofmt_e2e` — passes on the reformatted tree
- Dropping a deliberately misformatted file into `e2e/` — the target fails with the file listed and a non-zero exit, so the guard is real and not a no-op
- `make lint` — 0 issues
